### PR TITLE
Update to .NET 5.0

### DIFF
--- a/Hashgraph.SigningTool/Hashgraph.SigningTool.csproj
+++ b/Hashgraph.SigningTool/Hashgraph.SigningTool.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>logo.ico</ApplicationIcon>
     <Platforms>AnyCPU;x64;x86</Platforms>

--- a/Hashgraph.UI.WPF/Hashgraph.UI.WPF.csproj
+++ b/Hashgraph.UI.WPF/Hashgraph.UI.WPF.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon />
     <StartupObject />
@@ -18,7 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hashgraph" Version="4.1.0" />
+    <PackageReference Include="Hashgraph" Version="7.3.0" />
+    <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix SDK warnings and update Hashgraph to latest nuget release, required adding NSec.Cryptography package.